### PR TITLE
TESTED!

### DIFF
--- a/system/components/cookie.php
+++ b/system/components/cookie.php
@@ -1,9 +1,5 @@
 <?php
 
-/*****************
- *  ! UNTESTED ! *
- *****************/
-
 class Cookie
 {
     
@@ -31,7 +27,7 @@ class Cookie
      * @param string 	$secure
      * @param string 	$httpOnly
      */
-    static function set ($varName, $value, $time = 604800, $secure = false, $httpOnly = false)
+    static function set ($varName, $value, $time = 604800, $secure = false, $httpOnly = true )
     {
 
         setcookie ($varName, $value, $time, "/", BASEPATH, $secure, $httpOnly);


### PR DESCRIPTION
setting httpOnly to true prevents javascript (and other script langs) from accessing it. 
setting secure to true sends the cookie over an secure connection (https) so that might not be a good default.